### PR TITLE
fix: 초기 값 train, 1000판으로 변경

### DIFF
--- a/gui/launcher.py
+++ b/gui/launcher.py
@@ -66,7 +66,7 @@ class Launcher(QWidget):
         mode_layout = QHBoxLayout()
         self.radio_train = QRadioButton("학습 (Train)")
         self.radio_test = QRadioButton("평가 (Test)")
-        self.radio_test.setChecked(True)
+        self.radio_train.setChecked(True)
 
         btn_group = QButtonGroup(self)
         btn_group.addButton(self.radio_train)
@@ -82,7 +82,7 @@ class Launcher(QWidget):
         ep_layout = QVBoxLayout()
         self.ep_spin = QSpinBox()
         self.ep_spin.setRange(1, 10000)
-        self.ep_spin.setValue(1)
+        self.ep_spin.setValue(1000)
         ep_layout.addWidget(self.ep_spin)
         ep_group.setLayout(ep_layout)
         layout.addWidget(ep_group)


### PR DESCRIPTION
## 🔍 작업 배경 (Background)
- 매 시뮬레이션 시작마다 초기 값 설정의 불편

## 🛠 작업 요약 (Summary)
- 초기 값을 1000판과 train으로 고정

## 💬 리뷰 포인트 (Key Changes)
- 작동 여부

## 🏷️ 작업 종류 (Type of Change)
- [x] ✨ 기능 추가 (New Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 작업 (Documentation)
- [ ] 🔧 환경 설정 및 기타 (Config & Other)

## 📸 스크린샷 또는 실행 로그 (Screenshots / Logs)
## ✅ 체크리스트 (Self Checklist)
- [ ] 코드가 정상적으로 실행되며 에러가 발생하지 않습니다.
- [ ] **API 명세(입출력 규격)를 준수했습니다.** (Gymnasium Env 등)
- [ ] 불필요한 주석이나 디버깅 코드(`print` 등)를 정리했습니다.
- [ ] (필요한 경우) `requirements.txt`에 패키지를 추가했습니다.