### PR TITLE
fix: Resolve PPO device mismatch error

### DIFF
--- a/ai/algorithms/ppo.py
+++ b/ai/algorithms/ppo.py
@@ -34,6 +34,7 @@ class PPO:
             num_layers=model.num_layers,
         )
         self.policy_old.load_state_dict(self.policy.state_dict())
+        self.policy_old.to(next(self.policy.parameters()).device)
 
         self.MseLoss = nn.MSELoss()
 


### PR DESCRIPTION
## 🔍 작업 배경 (Background)
- PPO 학습 시 GPU 환경에서 `RuntimeError: Input and parameter tensors are not at the same device` 에러가 발생했습니다.
- `policy_old` 모델이 초기화 시 디바이스로 이동하지 않아 발생한 문제입니다.

## 🛠 작업 요약 (Summary)
- `ai/algorithms/ppo.py`: `PPO.__init__`에서 `policy_old`를 `policy`와 동일한 디바이스로 이동하도록 수정했습니다.
- `config.py`: `DEVICE` 설정을 `torch.cuda.is_available()`을 사용하여 자동으로 설정하도록 개선했습니다.
- `.gitignore`, `README.md`: 관련 설정 및 문서 업데이트.

## 💬 리뷰 포인트 (Key Changes)
- `ai/algorithms/ppo.py`의 `__init__` 메서드에서 `self.policy_old.to(...)` 추가 부분.

## 🏷️ 작업 종류 (Type of Change)
- [ ] ✨ 기능 추가 (New Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 작업 (Documentation)
- [x] 🔧 환경 설정 및 기타 (Config & Other)

## ✅ 체크리스트 (Self Checklist)
- [x] 코드가 정상적으로 실행되며 에러가 발생하지 않습니다.
- [x] **API 명세(입출력 규격)를 준수했습니다.** (Gymnasium Env 등)
- [x] 불필요한 주석이나 디버깅 코드(`print` 등)를 정리했습니다.
- [x] (필요한 경우) `requirements.txt`에 패키지를 추가했습니다.